### PR TITLE
Use Symfony 3.0 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     },
     "require": {
         "php": ">=5.5.1",
-        "symfony/framework-bundle": "~2.6",
-        "symfony/dependency-injection": "~2.6",
-        "symfony/yaml": "~2.3",
+        "symfony/framework-bundle": "~2.6|~3.0",
+        "symfony/dependency-injection": "~2.6|~3.0",
+        "symfony/yaml": "~2.3|~3.0",
         "lightSAML/lightSAML": "dev-master"
     },
     "require-dev": {


### PR DESCRIPTION
This small patch allows usage of Symfony 3.0 components in case the bundle is used in conjunction with Symfony 3.0.