### PR TITLE
Pass actual factory reference instead of Definition

### DIFF
--- a/src/LightSaml/SymfonyBridgeBundle/DependencyInjection/LightSamlSymfonyBridgeExtension.php
+++ b/src/LightSaml/SymfonyBridgeBundle/DependencyInjection/LightSamlSymfonyBridgeExtension.php
@@ -62,7 +62,7 @@ class LightSamlSymfonyBridgeExtension extends Extension
 
     private function configureCredentialStore(ContainerBuilder $container, array $config)
     {
-        $factoryReference = $container->getDefinition('lightsaml.credential.credential_store_factory');
+        $factoryReference = new Reference('lightsaml.credential.credential_store_factory');
         $definition = $container->getDefinition('lightsaml.credential.credential_store');
         $this->setFactoryCompatibleWay($definition, $factoryReference, 'buildFromOwnCredentialStore');
     }
@@ -74,7 +74,7 @@ class LightSamlSymfonyBridgeExtension extends Extension
 
     private function configureServiceCredentialResolver(ContainerBuilder $container, array $config)
     {
-        $factoryReference = $container->getDefinition('lightsaml.service.credential_resolver_factory');
+        $factoryReference = new Reference('lightsaml.service.credential_resolver_factory');
         $definition = $container->getDefinition('lightsaml.service.credential_resolver');
         $this->setFactoryCompatibleWay($definition, $factoryReference, 'build');
     }


### PR DESCRIPTION
Currently in some places Definitions are passed instead of References. Because of the way the PhpDumper works, the factory method is still called, but it's not called on the service but on a new instance of the factory class. 
This PR fixes that, so that the actual factory service is called. 