### PR TITLE
Removing use of Class::class for PHP 5.6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name": "lightsaml/symfony-bridge",
+    "name": "kidatsy/lightsaml-symfony-bridge",
     "license": "MIT",
     "type": "symfony-bundle",
-    "description": "Light SAML Symfony bridge bundle",
+    "description": "Clone of Light SAML Symfony bridge bundle, enabling PHP 5.6",
     "homepage": "http://www.lightsaml.com",
     "authors": [
         {
@@ -10,6 +10,12 @@
             "email": "tmilos@gmail.com",
             "homepage": "http://github.com/tmilos",
             "role": "Developer"
+        },
+        {
+            "name": "Toshiro Kida",
+            "email": "toshiro.kida@gmail.com",
+            "homepage": "https://github.com/kidatsy",
+            "role": "Cloner"
         }
     ],
     "autoload": {
@@ -23,14 +29,14 @@
         "symfony/framework-bundle": "~2.3|~3.0",
         "symfony/dependency-injection": "~2.3|~3.0",
         "symfony/yaml": "~2.3|~3.0",
-        "lightsaml/lightsaml": "~1.1"
+        "kidatsy/lightsaml-lightsaml": "~1.2"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",
         "satooshi/php-coveralls": "~0.6"
     },
     "suggest": {
-        "lightsaml/lightsamp-idp": "If you will be using IDP LightSAML services"
+        "kidatsy/lightsaml-lightsamp-idp": "If you will be using IDP LightSAML services"
     },
     "config": {
         "bin-dir": "bin"

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name": "kidatsy/lightsaml-symfony-bridge",
+    "name": "lightsaml/symfony-bridge",
     "license": "MIT",
     "type": "symfony-bundle",
-    "description": "Clone of Light SAML Symfony bridge bundle, enabling PHP 5.6",
+    "description": "Light SAML Symfony bridge bundle",
     "homepage": "http://www.lightsaml.com",
     "authors": [
         {
@@ -10,12 +10,6 @@
             "email": "tmilos@gmail.com",
             "homepage": "http://github.com/tmilos",
             "role": "Developer"
-        },
-        {
-            "name": "Toshiro Kida",
-            "email": "toshiro.kida@gmail.com",
-            "homepage": "https://github.com/kidatsy",
-            "role": "Cloner"
         }
     ],
     "autoload": {
@@ -29,14 +23,14 @@
         "symfony/framework-bundle": "~2.3|~3.0",
         "symfony/dependency-injection": "~2.3|~3.0",
         "symfony/yaml": "~2.3|~3.0",
-        "kidatsy/lightsaml-lightsaml": "~1.2"
+        "lightsaml/lightsaml": "~1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.5",
         "satooshi/php-coveralls": "~0.6"
     },
     "suggest": {
-        "kidatsy/lightsaml-lightsamp-idp": "If you will be using IDP LightSAML services"
+        "lightsaml/lightsamp-idp": "If you will be using IDP LightSAML services"
     },
     "config": {
         "bin-dir": "bin"

--- a/src/LightSaml/SymfonyBridgeBundle/Bridge/Container/BuildContainer.php
+++ b/src/LightSaml/SymfonyBridgeBundle/Bridge/Container/BuildContainer.php
@@ -12,13 +12,6 @@
 namespace LightSaml\SymfonyBridgeBundle\Bridge\Container;
 
 use LightSaml\Build\Container\BuildContainerInterface;
-use LightSaml\Build\Container\CredentialContainerInterface;
-use LightSaml\Build\Container\OwnContainerInterface;
-use LightSaml\Build\Container\PartyContainerInterface;
-use LightSaml\Build\Container\ProviderContainerInterface;
-use LightSaml\Build\Container\ServiceContainerInterface;
-use LightSaml\Build\Container\StoreContainerInterface;
-use LightSaml\Build\Container\SystemContainerInterface;
 
 class BuildContainer extends AbstractContainer implements BuildContainerInterface
 {
@@ -30,7 +23,7 @@ class BuildContainer extends AbstractContainer implements BuildContainerInterfac
      */
     public function getSystemContainer()
     {
-        return $this->getContainer(SystemContainer::class);
+        return $this->getContainer('SystemContainer');
     }
 
     /**
@@ -38,7 +31,7 @@ class BuildContainer extends AbstractContainer implements BuildContainerInterfac
      */
     public function getPartyContainer()
     {
-        return $this->getContainer(PartyContainer::class);
+        return $this->getContainer('PartyContainer');
     }
 
     /**
@@ -46,7 +39,7 @@ class BuildContainer extends AbstractContainer implements BuildContainerInterfac
      */
     public function getStoreContainer()
     {
-        return $this->getContainer(StoreContainer::class);
+        return $this->getContainer('StoreContainer');
     }
 
     /**
@@ -54,7 +47,7 @@ class BuildContainer extends AbstractContainer implements BuildContainerInterfac
      */
     public function getProviderContainer()
     {
-        return $this->getContainer(ProviderContainer::class);
+        return $this->getContainer('ProviderContainer');
     }
 
     /**
@@ -62,7 +55,7 @@ class BuildContainer extends AbstractContainer implements BuildContainerInterfac
      */
     public function getCredentialContainer()
     {
-        return $this->getContainer(CredentialContainer::class);
+        return $this->getContainer('CredentialContainer');
     }
 
     /**
@@ -70,7 +63,7 @@ class BuildContainer extends AbstractContainer implements BuildContainerInterfac
      */
     public function getServiceContainer()
     {
-        return $this->getContainer(ServiceContainer::class);
+        return $this->getContainer('ServiceContainer');
     }
 
     /**
@@ -78,7 +71,7 @@ class BuildContainer extends AbstractContainer implements BuildContainerInterfac
      */
     public function getOwnContainer()
     {
-        return $this->getContainer(OwnContainer::class);
+        return $this->getContainer('OwnContainer');
     }
 
     /**
@@ -86,12 +79,14 @@ class BuildContainer extends AbstractContainer implements BuildContainerInterfac
      *
      * @return AbstractContainer
      */
-    private function getContainer($class)
+    private function getContainer($className)
     {
-        if (false === isset($this->containers[$class])) {
-            $this->containers[$class] = new $class($this->container);
+        $fullName = 'LightSaml\SymfonyBridgeBundle\Bridge\Container\\' . $className;
+
+        if (false === isset($this->containers[$className])) {
+            $this->containers[$className] = new $fullName($this->container);
         }
 
-        return $this->containers[$class];
+        return $this->containers[$className];
     }
 }


### PR DESCRIPTION
Using the static `::class` property to get the name of a class is only compatible with PHP 5.5, according to this StackOverflow article: http://stackoverflow.com/questions/29862558/unexpected-class-t-class-only-on-remote-not-in-local. This removes `::class` in favor of using the full class name in order to instantiate the objects, to make the bundle compatible with PHP 5.6.

Submitting similar PR for https://github.com/lightSAML/lightSAML: https://github.com/lightSAML/lightSAML/pull/86