### PR TITLE
Fix login_check route name

### DIFF
--- a/src/LightSaml/SymfonyBridgeBundle/Resources/config/own.yml
+++ b/src/LightSaml/SymfonyBridgeBundle/Resources/config/own.yml
@@ -1,6 +1,6 @@
 parameters:
     lightsaml.own.entity_id: ~
-    lightsaml.route.login_check: lightsaml.login_check
+    lightsaml.route.login_check: lightsaml_sp.login_check
 
 services:
     lightsaml.own.credential_store:


### PR DESCRIPTION
It appears the name in the bridge isn't the same as in the bundle, not sure if there is a reason for this ?
I got an error because of it so here is a fix.