### PR TITLE
Switch from lightsaml/lightsaml to litesaml/lightsaml instead

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/framework-bundle": "~2.7|~3.0|~4.0",
         "symfony/dependency-injection": "~2.7|~3.0|~4.0",
         "symfony/yaml": "~2.7|~3.0|~4.0",
-        "lightsaml/lightsaml": "~1.1"
+        "litesaml/lightsaml": "~1.1"
     },
     "require-dev": {
         "symfony/browser-kit": "~2.7|~3.0|~4.0",


### PR DESCRIPTION
According to https://packagist.org/packages/lightsaml/lightsaml we should switch to prevent: `Package lightsaml/lightsaml is abandoned, you should avoid using it. Use litesaml/lightsaml instead.`